### PR TITLE
Bump Arcane.Framework version

### DIFF
--- a/src/Arcane.Stream.RestApi.csproj
+++ b/src/Arcane.Stream.RestApi.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Arcane.Framework" Version="0.0.16" />
+        <PackageReference Include="Arcane.Framework" Version="0.0.17" />
         <PackageReference Include="System.Text.Json" Version="8.0.3" />
     </ItemGroup>
     

--- a/src/Arcane.Stream.RestApi.csproj
+++ b/src/Arcane.Stream.RestApi.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Arcane.Framework" Version="0.0.15" />
+        <PackageReference Include="Arcane.Framework" Version="0.0.16" />
         <PackageReference Include="System.Text.Json" Version="8.0.3" />
     </ItemGroup>
     

--- a/src/Models/RestApiFixedAuthStreamContext.cs
+++ b/src/Models/RestApiFixedAuthStreamContext.cs
@@ -33,6 +33,11 @@ public class RestApiFixedAuthStreamContext : RestApiFixedAuthBase
     /// </summary>
     [JsonConverter(typeof(UnixTimeConverter))]
     public DateTimeOffset BackFillStartDate { get; init; }
+    
+    /// <summary>
+    /// Properties to traverse before [{..}, {..}, ..] structure is reached in the response.
+    /// </summary>
+    public string[] ResponsePropertyKeyChain { get; init; }
 
     /// <summary>
     /// Number of JsonElements per single json file.

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,21 +1,16 @@
 ﻿using System;
 using System.Reflection;
-using Amazon.S3;
 using Arcane.Framework.Contracts;
 using Arcane.Framework.Providers;
 using Arcane.Framework.Providers.Hosting;
 using Arcane.Stream.RestApi.Models;
 using Arcane.Stream.RestApi.Models.Base;
 using Arcane.Stream.RestApi.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
-using Snd.Sdk.Hosting;
 using Snd.Sdk.Logs.Providers;
 using Snd.Sdk.Metrics.Configurations;
 using Snd.Sdk.Metrics.Providers;
-using Snd.Sdk.Storage.Amazon;
-using Snd.Sdk.Storage.Base;
 using Snd.Sdk.Storage.Providers;
 using Snd.Sdk.Storage.Providers.Configurations;
 

--- a/src/Services/RestApiGraphBuilder.cs
+++ b/src/Services/RestApiGraphBuilder.cs
@@ -78,9 +78,8 @@ public class RestApiGraphBuilder: IStreamGraphBuilder<IStreamContext>
             TimeSpan.FromSeconds(context.LookbackInterval),
             TimeSpan.FromSeconds(context.HttpTimeout),
             context.IsBackfilling,
-            context.StreamKind,
             rateLimitPolicy,
-            RestApiExtensions.ParseOpenApiSchema(context.ApiSchemaEncoded),
+            context.ApiSchemaEncoded.ParseOpenApiSchema(),
             context.ResponsePropertyKeyChain);
     }
 
@@ -125,7 +124,7 @@ public class RestApiGraphBuilder: IStreamGraphBuilder<IStreamContext>
             TimeSpan.FromSeconds(configuration.HttpTimeout),
             configuration.IsBackfilling,
             rateLimitPolicy,
-            RestApiExtensions.ParseOpenApiSchema(configuration.ApiSchemaEncoded),
+            configuration.ApiSchemaEncoded.ParseOpenApiSchema(),
             configuration.ResponsePropertyKeyChain);
     }
 
@@ -151,7 +150,7 @@ public class RestApiGraphBuilder: IStreamGraphBuilder<IStreamContext>
             TimeSpan.FromSeconds(context.HttpTimeout),
             context.IsBackfilling,
             rateLimitPolicy,
-            RestApiExtensions.ParseOpenApiSchema(context.ApiSchemaEncoded),
+            context.ApiSchemaEncoded.ParseOpenApiSchema(),
             context.ResponsePropertyKeyChain);
     }
 }

--- a/src/Services/RestApiGraphBuilder.cs
+++ b/src/Services/RestApiGraphBuilder.cs
@@ -80,7 +80,8 @@ public class RestApiGraphBuilder: IStreamGraphBuilder<IStreamContext>
             context.IsBackfilling,
             context.StreamKind,
             rateLimitPolicy,
-            RestApiExtensions.ParseOpenApiSchema(context.ApiSchemaEncoded));
+            RestApiExtensions.ParseOpenApiSchema(context.ApiSchemaEncoded),
+            context.ResponsePropertyKeyChain);
     }
 
     private RestApiSource GetSource(RestApiPagedDynamicAuthStreamContext configuration)


### PR DESCRIPTION
This pull request backports bugfixes from internal repository (missing `responcePropertyKeyChain`)

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.
