### PR TITLE
Fix incorrect da viewer role name

### DIFF
--- a/.helm/templates/cluster-role-crd-rest-api-da-viewer.yaml
+++ b/.helm/templates/cluster-role-crd-rest-api-da-viewer.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "app.clusteRole.restApiFixedAuthViewer" . }}
+  name: {{ include "app.clusteRole.restApiDynamicAuthViewer" . }}
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"


### PR DESCRIPTION
This pull request fixes incorrect role name for the dynamic auth resources.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.
