### PR TITLE
Bump framework 2

### DIFF
--- a/src/Arcane.Stream.RestApi.csproj
+++ b/src/Arcane.Stream.RestApi.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Arcane.Framework" Version="0.0.19" />
+        <PackageReference Include="Arcane.Framework" Version="0.0.24" />
         <PackageReference Include="System.Text.Json" Version="8.0.3" />
     </ItemGroup>
     

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -20,7 +20,7 @@ int exitCode;
 try
 {
     exitCode = await Host.CreateDefaultBuilder(args)
-        .AddDatadogLogging((_, _, configuration) => configuration.WriteTo.Console())
+        .AddDatadogLogging((_, _, configuration) => configuration.EnrichWithCustomProperties().WriteTo.Console())
         .ConfigureRequiredServices(services =>
         {
             return services.AddStreamGraphBuilder<RestApiGraphBuilder>(context =>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -41,7 +41,6 @@ try
         })
         .ConfigureAdditionalServices((services, context) =>
         {
-            services.AddAzureBlob(AzureStorageConfiguration.CreateDefault());
             services.AddDatadogMetrics(configuration: DatadogConfiguration.UnixDomainSocket(context.ApplicationName));
             services.AddAwsS3Writer(AmazonStorageConfiguration.CreateFromEnv());
         })


### PR DESCRIPTION
Bump Arcane.Framework to 0.0.24
Add custom logging properties to the streaming job.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.
