### PR TITLE
Fix viewer cluster role for api fa stream

### DIFF
--- a/.helm/templates/cluster-role-crd-rest-api-fa-viewer.yaml
+++ b/.helm/templates/cluster-role-crd-rest-api-fa-viewer.yaml
@@ -7,10 +7,10 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     {{- include "app.labels" $ | nindent 4 }}
-    {{- with .Values.rbac.clusterRole.restApiFixedAuthEditor.additionalLabels }}
+    {{- with .Values.rbac.clusterRole.restApiFixedAuthViewer.additionalLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.rbac.clusterRole.restApiFixedAuthEditor.additionalAnnotations }}
+  {{- with .Values.rbac.clusterRole.restApiFixedAuthViewer.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
## Scope

Implemented:
- Viewer cluster role was pointing to the wrong value

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
