### PR TITLE
Fix incorrect reading the changeCaptureIntervalSeconds property

### DIFF
--- a/src/Models/RestApiDynamicAuthStreamContext.cs
+++ b/src/Models/RestApiDynamicAuthStreamContext.cs
@@ -69,6 +69,7 @@ public class RestApiDynamicAuthStreamContext : RestApiDynamicAuthBase
     /// <summary>
     /// How long to wait before polling for next result set.
     /// </summary>
+    [JsonPropertyName("changeCaptureIntervalSeconds")]
     public int ChangeCaptureInterval { get; init; }
     
     /// <summary>

--- a/src/Models/RestApiPagedDynamicAuthStreamContext.cs
+++ b/src/Models/RestApiPagedDynamicAuthStreamContext.cs
@@ -79,7 +79,6 @@ public class RestApiPagedDynamicAuthStreamContext : RestApiDynamicAuthBase
     /// <summary>
     /// How long to wait before polling for next result set.
     /// </summary>
-    [JsonConverter(typeof(SecondsToTimeSpanConverter))]
     [JsonPropertyName("changeCaptureIntervalSeconds")]
     public int ChangeCaptureInterval { get; init; }
     

--- a/src/Models/RestApiPagedDynamicAuthStreamContext.cs
+++ b/src/Models/RestApiPagedDynamicAuthStreamContext.cs
@@ -79,6 +79,8 @@ public class RestApiPagedDynamicAuthStreamContext : RestApiDynamicAuthBase
     /// <summary>
     /// How long to wait before polling for next result set.
     /// </summary>
+    [JsonConverter(typeof(SecondsToTimeSpanConverter))]
+    [JsonPropertyName("changeCaptureIntervalSeconds")]
     public int ChangeCaptureInterval { get; init; }
     
     /// <summary>

--- a/src/Models/RestApiPagedFixedAuthStreamContext.cs
+++ b/src/Models/RestApiPagedFixedAuthStreamContext.cs
@@ -74,7 +74,6 @@ public class RestApiPagedFixedAuthStreamContext : RestApiFixedAuthBase
     /// <summary>
     /// How long to wait before polling for next result set.
     /// </summary>
-    [JsonConverter(typeof(SecondsToTimeSpanConverter))]
     [JsonPropertyName("changeCaptureIntervalSeconds")]
     public int ChangeCaptureInterval { get; init; }
     

--- a/src/Models/RestApiPagedFixedAuthStreamContext.cs
+++ b/src/Models/RestApiPagedFixedAuthStreamContext.cs
@@ -74,6 +74,7 @@ public class RestApiPagedFixedAuthStreamContext : RestApiFixedAuthBase
     /// <summary>
     /// How long to wait before polling for next result set.
     /// </summary>
+    [JsonConverter(typeof(SecondsToTimeSpanConverter))]
     [JsonPropertyName("changeCaptureIntervalSeconds")]
     public int ChangeCaptureInterval { get; init; }
     


### PR DESCRIPTION
**URGENT**: Fixes the incorrect ChangeCaptureInterval property in Arcane streams.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
