### PR TITLE
Add arcane operator v1 support

### DIFF
--- a/.helm/templates/crd-rest-api-da.yaml
+++ b/.helm/templates/crd-rest-api-da.yaml
@@ -169,6 +169,7 @@ spec:
                   type: string
                 configurationHash:
                   description: ConfigurationHash represents the hash of the current configuration.
+                  type: string
                 conditions:
                   type: array
                   items:

--- a/.helm/templates/crd-rest-api-da.yaml
+++ b/.helm/templates/crd-rest-api-da.yaml
@@ -38,6 +38,9 @@ spec:
             spec:
               type: object
               properties:
+                suspended:
+                  description: Suspended indicates whether the stream is suspended.
+                  type: boolean
                 credentialSecretRef:
                   description: |
                     Name of the secret containing the connection string.
@@ -164,14 +167,8 @@ spec:
               properties:
                 phase:
                   type: string
-                  enum:
-                    - RESTARTING
-                    - RUNNING
-                    - RELOADING
-                    - TERMINATING
-                    - STOPPED
-                    - SUSPENDED
-                    - FAILED
+                configurationHash:
+                  description: ConfigurationHash represents the hash of the current configuration.
                 conditions:
                   type: array
                   items:
@@ -184,11 +181,6 @@ spec:
                         type: string
                       type:
                         type: string
-                        enum:
-                          - WARNING
-                          - ERROR
-                          - INFO
-                          - READY
                       status:
                         type: string
                         enum: 

--- a/.helm/templates/crd-rest-api-fa.yaml
+++ b/.helm/templates/crd-rest-api-fa.yaml
@@ -38,6 +38,9 @@ spec:
             spec:
               type: object
               properties:
+                suspended:
+                  description: Suspended indicates whether the stream is suspended.
+                  type: boolean
                 credentialSecretRef:
                   description: |
                     Name of the secret containing the REST API credentials.
@@ -156,14 +159,8 @@ spec:
               properties:
                 phase:
                   type: string
-                  enum:
-                    - RESTARTING
-                    - RUNNING
-                    - RELOADING
-                    - TERMINATING
-                    - STOPPED
-                    - SUSPENDED
-                    - FAILED
+                configurationHash:
+                  description: ConfigurationHash represents the hash of the current configuration.
                 conditions:
                   type: array
                   items:
@@ -176,11 +173,6 @@ spec:
                         type: string
                       type:
                         type: string
-                        enum:
-                          - WARNING
-                          - ERROR
-                          - INFO
-                          - READY
                       status:
                         type: string
                         enum: 

--- a/.helm/templates/crd-rest-api-fa.yaml
+++ b/.helm/templates/crd-rest-api-fa.yaml
@@ -161,6 +161,7 @@ spec:
                   type: string
                 configurationHash:
                   description: ConfigurationHash represents the hash of the current configuration.
+                  type: string
                 conditions:
                   type: array
                   items:

--- a/.helm/templates/crd-rest-api-paged-da.yaml
+++ b/.helm/templates/crd-rest-api-paged-da.yaml
@@ -38,6 +38,9 @@ spec:
             spec:
               type: object
               properties:
+                suspended:
+                  description: Suspended indicates whether the stream is suspended.
+                  type: boolean
                 credentialSecretRef:
                   description: |
                     Name of the secret containing the REST API credentials.
@@ -186,14 +189,8 @@ spec:
               properties:
                 phase:
                   type: string
-                  enum:
-                    - RESTARTING
-                    - RUNNING
-                    - RELOADING
-                    - TERMINATING
-                    - STOPPED
-                    - SUSPENDED
-                    - FAILED
+                configurationHash:
+                  description: ConfigurationHash represents the hash of the current configuration.
                 conditions:
                   type: array
                   items:
@@ -206,11 +203,6 @@ spec:
                         type: string
                       type:
                         type: string
-                        enum:
-                          - WARNING
-                          - ERROR
-                          - INFO
-                          - READY
                       status:
                         type: string
                         enum: 

--- a/.helm/templates/crd-rest-api-paged-da.yaml
+++ b/.helm/templates/crd-rest-api-paged-da.yaml
@@ -191,6 +191,7 @@ spec:
                   type: string
                 configurationHash:
                   description: ConfigurationHash represents the hash of the current configuration.
+                  type: string
                 conditions:
                   type: array
                   items:

--- a/.helm/templates/crd-rest-api-paged-fa.yaml
+++ b/.helm/templates/crd-rest-api-paged-fa.yaml
@@ -38,6 +38,9 @@ spec:
             spec:
               type: object
               properties:
+                suspended:
+                  description: Suspended indicates whether the stream is suspended.
+                  type: boolean
                 credentialSecretRef:
                   description: |
                     Name of the secret containing the REST API credentials.
@@ -184,14 +187,8 @@ spec:
               properties:
                 phase:
                   type: string
-                  enum:
-                    - RESTARTING
-                    - RUNNING
-                    - RELOADING
-                    - TERMINATING
-                    - STOPPED
-                    - SUSPENDED
-                    - FAILED
+                configurationHash:
+                  description: ConfigurationHash represents the hash of the current configuration.
                 conditions:
                   type: array
                   items:
@@ -204,11 +201,6 @@ spec:
                         type: string
                       type:
                         type: string
-                        enum:
-                          - WARNING
-                          - ERROR
-                          - INFO
-                          - READY
                       status:
                         type: string
                         enum: 

--- a/.helm/templates/crd-rest-api-paged-fa.yaml
+++ b/.helm/templates/crd-rest-api-paged-fa.yaml
@@ -189,6 +189,7 @@ spec:
                   type: string
                 configurationHash:
                   description: ConfigurationHash represents the hash of the current configuration.
+                  type: string
                 conditions:
                   type: array
                   items:

--- a/.helm/templates/streamclass-restapi-da.yaml
+++ b/.helm/templates/streamclass-restapi-da.yaml
@@ -1,4 +1,4 @@
-apiVersion: streaming.sneaksanddata.com/v1beta1
+apiVersion: streaming.sneaksanddata.com/v1
 kind: StreamClass
 metadata:
   name: {{ template "app.name" . }}-da

--- a/.helm/templates/streamclass-restapi-fa.yaml
+++ b/.helm/templates/streamclass-restapi-fa.yaml
@@ -1,4 +1,4 @@
-apiVersion: streaming.sneaksanddata.com/v1beta1
+apiVersion: streaming.sneaksanddata.com/v1
 kind: StreamClass
 metadata:
   name: {{ template "app.name" . }}-fa

--- a/.helm/templates/streamclass-restapi-paged-da.yaml
+++ b/.helm/templates/streamclass-restapi-paged-da.yaml
@@ -1,4 +1,4 @@
-apiVersion: streaming.sneaksanddata.com/v1beta1
+apiVersion: streaming.sneaksanddata.com/v1
 kind: StreamClass
 metadata:
   name: {{ template "app.name" . }}-paged-da

--- a/.helm/templates/streamclass-restapi-paged-fa.yaml
+++ b/.helm/templates/streamclass-restapi-paged-fa.yaml
@@ -1,4 +1,4 @@
-apiVersion: streaming.sneaksanddata.com/v1beta1
+apiVersion: streaming.sneaksanddata.com/v1
 kind: StreamClass
 metadata:
   name: {{ template "app.name" . }}-paged-fa


### PR DESCRIPTION
Part of Arcane 1.0 migration process.

## Scope

Implemented:
- Added the context fields required for Arcane Operator 1.0 to work correctly.


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.